### PR TITLE
Show provider weights in SV diagnostics

### DIFF
--- a/Pawn.lua
+++ b/Pawn.lua
@@ -464,7 +464,7 @@ SlashCmdList["XIVEPAWN"] = function(msg)
         rows[#rows+1] = {
           name         = r.name,
           tag          = r.tag,
-          values       = nil,
+          values       = r.values,
           active       = r.active,
           visible      = true,
           providerOnly = true,
@@ -473,12 +473,13 @@ SlashCmdList["XIVEPAWN"] = function(msg)
     end
 
     for _, r in ipairs(rows) do
-      print(("|cff66ccffXIVEquip|r SV: NAME=%s TAG=%s Active=%s Visible=%s Values=%s ProviderOnly=%s")
+      print(("|cff66ccffXIVEquip|r SV: NAME=%s TAG=%s Active=%s Visible=%s Values=%s ProviderOnly=%s ProviderValues=%s")
         :format(r.name or "—", r.tag or "—",
                 r.active and "Y" or "N",
                 r.visible and "Y" or "N",
                 r.values and "Y" or "N",
-                r.providerOnly and "Y" or "N"))
+                r.providerOnly and "Y" or "N",
+                (r.providerOnly and r.values) and "Y" or "N"))
     end
     return
   end


### PR DESCRIPTION
## Summary
- preserve provider scale weights when merging into /xivepawn sv output
- expand /xivepawn sv diagnostic logging to show when provider weights are retrieved

## Testing
- `luac -p Pawn.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa732aac832b9d027d832b1fa2bb